### PR TITLE
Correction to ATS deadline statements

### DIFF
--- a/en/ios/implement-app-transport-security.md
+++ b/en/ios/implement-app-transport-security.md
@@ -11,7 +11,7 @@ Implementing ATS includes a couple of options:
 
 ## Remediation
 
-For apps running on iOS 9.0 or higher, best practice is to enable ATS globally by linking to the iOS 9.0 or later SDK and *NOT* setting the `NSAllowsArbitraryLoads` key to `Yes` or `True`.  Apple currently allows developers to include exceptions for any domains for which TLS cannot be enforced. Exceptions can be made using the `NSExceptionAllowsInsecureHTTPLoads` or `NSThirdPartyExceptionAllowsInsecureHTTPLoads` keys. It is important to note that beginning in January 2017, Apple will no longer accept exceptions and all communications must use ATS.
+For apps running on iOS 9.0 or higher, best practice is to enable ATS globally by linking to the iOS 9.0 or later SDK and *NOT* setting the `NSAllowsArbitraryLoads` key to `Yes` or `True`.  Apple currently allows developers to include exceptions for any domains for which TLS cannot be enforced. Exceptions can be made using the `NSExceptionAllowsInsecureHTTPLoads` or `NSThirdPartyExceptionAllowsInsecureHTTPLoads` keys. It is important to note that beginning in January 2017, Apple will require appropriate justification from developers for any exceptions declared inside the application (During App Store review). Otherwise, all communications must use ATS.
 
 ## References
 


### PR DESCRIPTION
I corrected something in the statements surrounding Apple's January 2017 deadline for ATS compliance. Apple stated during WWDC that developers will be able to provide justifications for why exceptions should be granted. Acceptance will of course be at Apple's discretion during the app review process.
